### PR TITLE
Change install package ruby-build to ruby-install

### DIFF
--- a/_posts/2013-09-23-how_i_setup_chruby.markdown
+++ b/_posts/2013-09-23-how_i_setup_chruby.markdown
@@ -8,7 +8,7 @@ After having another battle with pow and rvm I thought I would give [chruby](htt
 
 ```bash
 brew install chruby
-brew install ruby-build
+brew install ruby-install
 ruby-install ruby 1.9.3
 ruby-install ruby 2.0
 ```
@@ -38,7 +38,7 @@ This should have you up and running now, but I have added two other steps to my 
 
 ### Bundler
 
-First of all, for ubndler I now use the `--path` option when I am first installing the gems for a project.
+First of all, for bundler I now use the `--path` option when I am first installing the gems for a project.
 
 ```bash
 bundle install --path ./vendor/bundle


### PR DESCRIPTION
Per our discussion walking back from lunch today, the setup should use `ruby-install` instead of `ruby-build`. The shell command sample shows the use of `ruby-install`, but not the `brew` packages.
